### PR TITLE
added end of support date and support level

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ See [CycloneDX official documentation](https://github.com/CycloneDX/cyclonedx-pr
 
 ## `interlynk:component`
 
-| Property Name                      | Description                     |
-| ---------------------------------- | --------------------------------|
-| `interlynk:component:component_id` | Identifier of the component     |
-| `interlynk:component:source`       | Source of the component         |
-| `interlynk:component:source_id`    | Identifier of the source        |
+| Property Name                            | Description                     |
+| -----------------------------------------| --------------------------------|
+| `interlynk:component:component_id`       | Identifier of the component     |
+| `interlynk:component:source`             | Source of the component         |
+| `interlynk:component:source_id`          | Identifier of the source        |
+| `interlynk:component:end_of_support_date`| Component end of support date   |
+| `interlynk:component:support_level`      | Support level of component      |
 
 ## `interlynk:service`
 


### PR DESCRIPTION
This PR adds interlynk `end_of_support_date` and `support_level` in the Interlynk CycloneDX Property Taxonomy